### PR TITLE
using absolute path instead of relative path

### DIFF
--- a/changes/add/content/en/docs/Experimentation/Iot-devices/_index.md
+++ b/changes/add/content/en/docs/Experimentation/Iot-devices/_index.md
@@ -18,17 +18,3 @@ to your laptop, and you drive the devices through an interactive control client.
 
 The `mrg-iot` command-line tool automates this entire lifecycle, and the `spiot_ctl`
 control interface is used to issue commands to the devices once they are running.
-
-## Which page do I need?
-
-- **[Quickstart](quickstart/)** — Start here. The shortest path from install to
-  interacting with a device, in a handful of commands.
-- **[Device Creation](device-creation/)** — The full reference for reserving,
-  materializing, and connecting to devices with `mrg-iot`, including the automated,
-  daemon, and manual workflows.
-- **[Device Interaction](device-interaction/)** — The complete command reference for
-  the `spiot_ctl` control interface: sending commands, querying async job results,
-  and automating workflows.
-- **[Troubleshooting & FAQ](troubleshooting/)** — Common errors and how to resolve
-  them: cleaning up leftover resources, login and connection problems, validation
-  rules, and device-command errors.

--- a/changes/add/content/en/docs/Experimentation/Iot-devices/device-creation/index.md
+++ b/changes/add/content/en/docs/Experimentation/Iot-devices/device-creation/index.md
@@ -6,7 +6,7 @@ description: >
     Reserve, materialize, and connect to Sphere IoT devices using the mrg-iot CLI or the Merge portal directly.
 ---
 
-New to IoT devices on Sphere? Start with the [Quickstart](content/en/docs/Experimentation/Iot-devices/quickstart/) for the
+New to IoT devices on Sphere? Start with the [Quickstart](/docs/Experimentation/Iot-devices/quickstart/) for the
 shortest path. This page is the complete reference for every creation workflow.
 
 ## Overview
@@ -218,7 +218,7 @@ If any selected device has an accessible camera, a VLC window opens automaticall
 
 **10. Interactive Session**
 
-The `spiot_ctl` prompt becomes available. See [Device Interaction](content/en/docs/Experimentation/Iot-devices/device-interaction/) for the full command reference.
+The `spiot_ctl` prompt becomes available. See [Device Interaction](/docs/Experimentation/Iot-devices/device-interaction/) for the full command reference.
 
 ### Post-Experiment Cleanup
 
@@ -440,6 +440,6 @@ mrg-iot xdc delete --project <project> --name <name>
 mrg-iot ctl              # connects to 192.168.254.1:17000 (default)
 ```
 
-This opens the same `spiot_ctl` prompt used by `mrg-iot run`. See [Device Interaction](content/en/docs/Experimentation/Iot-devices/quickstart/device-interaction/) for the full command reference.
+This opens the same `spiot_ctl` prompt used by `mrg-iot run`. See [Device Interaction](/docs/Experimentation/Iot-devices/quickstart/device-interaction/) for the full command reference.
 
 Command history is saved to `~/.spiot_history` (up to 500 entries).

--- a/changes/add/content/en/docs/Experimentation/Iot-devices/device-interaction/index.md
+++ b/changes/add/content/en/docs/Experimentation/Iot-devices/device-interaction/index.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 {{% alert title="Prerequisite" color="info" %}}
-This guide assumes IoT devices have already been reserved and an active session is running. See [Device Creation](content/en/docs/Experimentation/Iot-devices/device-creation/) for setup instructions, or the [Quickstart](content/en/docs/Experimentation/Iot-devices/quickstart/) for the short path.
+This guide assumes IoT devices have already been reserved and an active session is running. See [Device Creation](/docs/Experimentation/Iot-devices/device-creation/) for setup instructions, or the [Quickstart](/docs/Experimentation/Iot-devices/quickstart/) for the short path.
 {{% /alert %}}
 
 ## Overview

--- a/changes/add/content/en/docs/Experimentation/Iot-devices/quickstart/index.md
+++ b/changes/add/content/en/docs/Experimentation/Iot-devices/quickstart/index.md
@@ -89,7 +89,7 @@ realization and XDC.
 exit
 ```
 
-## Next steps
+## Detailed Steps
 
 - **[Device Creation](../device-creation/)** — interactive, non-interactive, and daemon
   modes; the manual `mergexp` path; and per-resource management commands.

--- a/changes/add/content/en/docs/Experimentation/Iot-devices/troubleshooting/index.md
+++ b/changes/add/content/en/docs/Experimentation/Iot-devices/troubleshooting/index.md
@@ -10,16 +10,15 @@ This page collects the issues users hit most often, grouped by where they occur:
 setup, login, resource conflicts, connection/tunnels, and device interaction. Each
 entry lists the symptom you'll see and the fix.
 
-{{% alert title="First step for almost any failure" color="info" %}}
-Re-run the command with the global `--debug` flag. This writes verbose logs to
+Run the command with the global `--debug` flag. This writes verbose logs to
 `~/.mrg-iot/debug.log`, and the background daemon writes to `~/.mrg-iot/daemon.log`.
 These two files contain the underlying SSH, gRPC, and portal errors behind most
-generic messages.
+generic messages. These can give you a more detailed overview of any issue.
+
 ```sh
 mrg-iot --debug run
-cat ~/.mrg-iot/daemon.log
+cat ~/.mrg-iot/debug.log
 ```
-{{% /alert %}}
 
 ## Exit codes
 


### PR DESCRIPTION
using absolute path instead of relative path, this will still fail if the crawler does not keep track of visited sites. If it fails I can get rid of the link completely.